### PR TITLE
日本の祝日判定ライブラリの作成

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  lint:
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  test:
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Test
+        run: go test -v -count=1 -race -cover -coverprofile=coverage ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+linters:
+  enable:
+    - goimports
+    - golint
+    - gosec
+
+linters-settings:
+  errcheck:
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: true
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.3
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+
+issues:
+  exclude-use-default: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+## Install library for production
+deps:
+	@go mod tidy
+.PHONY: deps
+
+fmt:
+	@go fmt ./...
+
+## Execute unit tests
+test:
+	@go test -v -count=1 -timeout 300s -short ./...
+.PHONY: test
+
+## Execute race tests
+test-race:
+	@go test -v -count=1 -timeout 300s -short -race ./...
+.PHONY: test-race
+
+## Execute integrated tests
+test-integration:
+	@go test -v -count=1 -timeout 600s ./...
+.PHONY: test-integration
+
+## Output coverage of testing
+cov:
+	@go test -count 1 -coverprofile=cover.out ./...
+	@go tool cover -html=cover.out
+.PHONY: cov
+
+## Lint
+lint:
+	golangci-lint run --tests
+.PHONY: lint
+
+# Execute this command before you creates a pull request
+pr-prep: fmt lint test-race test-integration
+
+## Help
+help:
+	@make2help --all
+.PHONY: help

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
+[![test](https://github.com/kenzo0107/shukujitsu/actions/workflows/test.yml/badge.svg)](https://github.com/kenzo0107/shukujitsu/actions/workflows/test.yml) [![lint](https://github.com/kenzo0107/shukujitsu/actions/workflows/lint.yml/badge.svg)](https://github.com/kenzo0107/shukujitsu/actions/workflows/lint.yml)
+
 # shukujitsu
-get and update holiday csv from cabinet office
+
+内閣府ホームページにて提供される日本の祝日データを元に、祝日判定・祝日名を取得する Go ライブラリです。
+
+
+## データセット
+
+[内閣府ホームページ](https://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html) で提供される [shukujitsu.csv](https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv) をベースとしております。
+
+GitHub Actions 内で定期的に取得します。
+
+## サンプルコード
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kenzo0107/shukujitsu"
+)
+
+func main() {
+	t, _ := time.Parse("2006-01-02", "2021-07-22")
+	if shukujitsu.IsHoliday(t) {
+		fmt.Println("there is a holiday")
+	}
+	fmt.Println(shukujitsu.HolidayName(t))
+}
+```

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kenzo0107/shukujitsu"
+)
+
+func main() {
+	t, _ := time.Parse("2006-01-02", "2021-07-22")
+	if shukujitsu.IsHoliday(t) {
+		fmt.Println("there is a holiday")
+	}
+	fmt.Println(shukujitsu.HolidayName(t))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/kenzo0107/shukujitsu
+
+go 1.16
+
+require gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/shukujitsu.go
+++ b/shukujitsu.go
@@ -1,0 +1,41 @@
+package shukujitsu
+
+import (
+	_ "embed" // Register a standard stuff
+	"errors"
+	"log"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+//go:embed shukujitsu.yml
+var b []byte
+
+var holidays map[string]string
+
+func init() {
+	if err := yaml.Unmarshal(b, &holidays); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// IsHoliday : 祝日判定
+func IsHoliday(t time.Time) bool {
+	_, ok := holidays[dateStr(t)]
+	return ok
+}
+
+// HolidayName : 祝日の名前
+func HolidayName(t time.Time) (string, error) {
+	name, ok := holidays[dateStr(t)]
+	if !ok {
+		return name, errors.New("not a holiday")
+	}
+	return name, nil
+}
+
+// csv の日付が 2021/7/22 形式である為、フォーマットを合わせる
+func dateStr(t time.Time) string {
+	return t.Format("2006/1/2")
+}

--- a/shukujitsu_test.go
+++ b/shukujitsu_test.go
@@ -1,0 +1,86 @@
+package shukujitsu
+
+import (
+	_ "embed"
+	"testing"
+	"time"
+)
+
+var (
+	notHoliday, _ = time.Parse("2006-01-02", "2021-07-19")
+	holiday, _    = time.Parse("2006-01-02", "2021-07-22")
+)
+
+func TestIsHoliday(t *testing.T) {
+	type args struct {
+		t time.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "there is a holiday",
+			args: args{
+				holiday,
+			},
+			want: true,
+		},
+		{
+			name: "there is not a holiday",
+			args: args{
+				notHoliday,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsHoliday(tt.args.t); got != tt.want {
+				t.Errorf("IsHoliday() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHolidayName(t *testing.T) {
+	type args struct {
+		t time.Time
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "there is a holiday",
+			args: args{
+				holiday,
+			},
+			want:    "海の日",
+			wantErr: false,
+		},
+		{
+			name: "there is not a holiday",
+			args: args{
+				notHoliday,
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HolidayName(tt.args.t)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("HolidayName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("HolidayName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
日本の祝日判定をするライブラリを作成する。

祝日情報は内閣府が提供する shukujitsu.csv を利用する。
毎月 1, 15 日に shukujitsu.csv を取得し、変更がある場合、自動コミットする。