### PR TITLE
毎週月曜2:00UTCに変更

### DIFF
--- a/.github/workflows/auto_update_shukujitsu.yml
+++ b/.github/workflows/auto_update_shukujitsu.yml
@@ -2,8 +2,8 @@ name: update shukujitsu.yml
 
 on:
   schedule:
-    # 毎月 1,15日 02:00 UTC に実行
-    - cron: '0 2 1,15 * *'
+    # 毎週月曜 02:00 UTC に実行
+    - cron: '0 2 * * MON'
 
 jobs:
   update_shukujitsu:


### PR DESCRIPTION
更新頻度が低く、 GitHub からcron実行をやめて良いか？というお知らせメールが届くので月2 から週1に変更して様子を見る